### PR TITLE
Feature / API Integration Strategy

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
     <script src="node_modules/super-repo/lib/index.js"></script>
 
     <script src="js/browser-extension-api.js"></script>
+    <script src="js/apiFakeAdapter.js"></script>
     <script src="js/api.js"></script>
     <script src="js/chart.js"></script>
     <script src="js/clock.js"></script>

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
     </div>
 
 
+    <script src="node_modules/axios/dist/axios.min.js"></script>
     <script src="node_modules/jquery/dist/jquery.min.js"></script>
     <script src="node_modules/chart.js/dist/Chart.min.js"></script>
     <script src="node_modules/moment/min/moment.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
 
     <script src="js/browser-extension-api.js"></script>
     <script src="js/apiFakeAdapter.js"></script>
+    <script src="js/apiGoranAdapter.js"></script>
     <script src="js/api.js"></script>
     <script src="js/chart.js"></script>
     <script src="js/clock.js"></script>

--- a/js/api.js
+++ b/js/api.js
@@ -38,10 +38,10 @@ window.App.API = {
             const hour = date.getHours();
 
             if (nextData[hour]) {
-              nextData[hour].average = (nextData[hour].average + rec.average) / 2;
+              nextData[hour].average.push(rec.average);
             } else {
                 nextData[hour] = {
-                  average: rec.average,
+                  average: [rec.average],
                   time: rec.time
                 };
             }
@@ -52,7 +52,10 @@ window.App.API = {
             result.push(nextData[key]);
           }
 
-          return result;
+          return result.map( rec => ({
+            average: parseInt(rec.average.reduce((a,b) => a + b) / rec.average.length),
+            time: rec.time
+          }));
         });
     },
 

--- a/js/api.js
+++ b/js/api.js
@@ -1,65 +1,44 @@
 window.App = window.App || {};
 
-window.App.API = {
-    baseURL: 'https://apiv2.bitcoinaverage.com/',
+class API {
+    constructor(apiAdapter) {
+        this.apiAdapter = apiAdapter;
+    }
 
-    fetch: function(_endpoint) {
-        return axios.get(this.baseURL + _endpoint)
+    get(_endpoint) {
+        return axios.get(this.apiAdapter.baseURL + _endpoint)
             .then( r => r.data )
             .catch( (jqXHR, textStatus, errorThrown) =>
                console.log(jqXHR, textStatus, errorThrown));
-    },
+    }
 
-    getBitcoinRatesForAll: function() {
-        return this.fetch('all');
-    },
+    mapData(_r, _period) {
+        return this.apiAdapter.mapData(_r, _period);
+    }
 
-    getBitcoinRatesForOneYear: function() {
-        return this.fetch('year');
-    },
+    getBitcoinRatesForAll() {
+        return this.apiAdapter.getBitcoinRatesForAll();
+    }
 
-    getBitcoinRatesForOneMonth: function() {
-        return this.fetch('month');
-    },
+    getBitcoinRatesForOneYear() {
+        return this.apiAdapter.getBitcoinRatesForOneYear();
+    }
 
-    getBitcoinRatesForOneWeek: function() {
-        return this.fetch('week');
-    },
+    getBitcoinRatesForOneMonth() {
+        return this.apiAdapter.getBitcoinRatesForOneMonth();
+    }
 
-    getBitcoinRatesForOneDay: function() {
-        return this.fetch('indices/global/history/BTCUSD?period=daily&?format=json').then(data => {
-          // TODO: Calculate avarage price per hour
+    getBitcoinRatesForOneWeek() {
+        return this.apiAdapter.getBitcoinRatesForOneWeek();
+    }
 
-          const nextData = {};
+    getBitcoinRatesForOneDay() {
+        return this.apiAdapter.getBitcoinRatesForOneDay();
+    }
 
-          data.forEach( rec => {
-            const date = new Date(rec.time);
-
-            const hour = date.getHours();
-
-            if (nextData[hour]) {
-              nextData[hour].average.push(rec.average);
-            } else {
-                nextData[hour] = {
-                  average: [rec.average],
-                  time: rec.time
-                };
-            }
-          });
-
-          const result = [];
-          for (let key of Object.keys(nextData)) {
-            result.push(nextData[key]);
-          }
-
-          return result.map( rec => ({
-            average: parseInt(rec.average.reduce((a,b) => a + b) / rec.average.length),
-            time: rec.time
-          }));
-        });
-    },
-
-    getBitcoinRatesForOneHour: function() {
-        return this.fetch('hour');
+    getBitcoinRatesForOneHour() {
+        return this.apiAdapter.getBitcoinRatesForOneHour();
     }
 };
+
+window.App.API = new API(App.apiFakeAdapter);

--- a/js/api.js
+++ b/js/api.js
@@ -4,9 +4,9 @@ window.App.API = {
     baseURL: 'fake-api/',
 
     fetch: function(_endpoint) {
-        return $.ajax({ url: this.baseURL + _endpoint + '.json' })
-            .then( _response => JSON.parse(_response) )
-            .fail( (jqXHR, textStatus, errorThrown) =>
+        return axios.get(this.baseURL + _endpoint + '.json')
+            .then( r => r.data )
+            .catch( (jqXHR, textStatus, errorThrown) =>
                console.log(jqXHR, textStatus, errorThrown));
     },
 

--- a/js/api.js
+++ b/js/api.js
@@ -41,4 +41,5 @@ class API {
     }
 };
 
-window.App.API = new API(App.apiFakeAdapter);
+// window.App.API = new API(App.apiFakeAdapter);
+window.App.API = new API(App.apiGoranAdapter);

--- a/js/api.js
+++ b/js/api.js
@@ -1,10 +1,10 @@
 window.App = window.App || {};
 
 window.App.API = {
-    baseURL: 'fake-api/',
+    baseURL: 'https://apiv2.bitcoinaverage.com/',
 
     fetch: function(_endpoint) {
-        return axios.get(this.baseURL + _endpoint + '.json')
+        return axios.get(this.baseURL + _endpoint)
             .then( r => r.data )
             .catch( (jqXHR, textStatus, errorThrown) =>
                console.log(jqXHR, textStatus, errorThrown));
@@ -27,7 +27,33 @@ window.App.API = {
     },
 
     getBitcoinRatesForOneDay: function() {
-        return this.fetch('day');
+        return this.fetch('indices/global/history/BTCUSD?period=daily&?format=json').then(data => {
+          // TODO: Calculate avarage price per hour
+
+          const nextData = {};
+
+          data.forEach( rec => {
+            const date = new Date(rec.time);
+
+            const hour = date.getHours();
+
+            if (nextData[hour]) {
+              nextData[hour].average = (nextData[hour].average + rec.average) / 2;
+            } else {
+                nextData[hour] = {
+                  average: rec.average,
+                  time: rec.time
+                };
+            }
+          });
+
+          const result = [];
+          for (let key of Object.keys(nextData)) {
+            result.push(nextData[key]);
+          }
+
+          return result;
+        });
     },
 
     getBitcoinRatesForOneHour: function() {

--- a/js/apiFakeAdapter.js
+++ b/js/apiFakeAdapter.js
@@ -1,0 +1,40 @@
+window.App = window.App || {};
+
+window.App.apiFakeAdapter = {
+    baseURL: 'fake-api/',
+
+    mapData: function(response, dateLabelFormat) {
+        return response.map( _rec => ({
+            value: _rec.value,
+            timestamp: moment(_rec.timestamp).format(dateLabelFormat)
+        }));
+    },
+
+    get: function(_endpoint) {
+        return App.API.get(_endpoint).then(r => r.data);
+    },
+
+    getBitcoinRatesForAll: function() {
+        return this.get('all.json');
+    },
+
+    getBitcoinRatesForOneYear: function() {
+        return this.get('year.json');
+    },
+
+    getBitcoinRatesForOneMonth: function() {
+        return this.get('month.json');
+    },
+
+    getBitcoinRatesForOneWeek: function() {
+        return this.get('week.json');
+    },
+
+    getBitcoinRatesForOneDay: function() {
+        return this.get('day.json');
+    },
+
+    getBitcoinRatesForOneHour: function() {
+        return this.get('hour.json');
+    }
+};

--- a/js/apiGoranAdapter.js
+++ b/js/apiGoranAdapter.js
@@ -19,11 +19,38 @@ window.App.apiGoranAdapter = {
     },
 
     getBitcoinRatesForAll: function() {
-        return this.get('all');
+        return this.get('indices/global/history/BTCUSD?period=alltime&?format=json').then(data => {
+            const nextData = {};
+
+            data.forEach( rec => {
+                const date = this._createDateAsUTC(new Date(rec.time));
+
+                const year = date.getFullYear();
+                const key = `${year}`;
+                if (nextData[key]) {
+                  nextData[key].average.push(rec.average);
+                } else {
+                    nextData[key] = {
+                      average: [rec.average],
+                      time: date.valueOf()
+                    };
+                }
+            });
+
+            const result = [];
+            for (let key of Object.keys(nextData)) {
+                result.push(nextData[key]);
+            }
+
+            return result.map( rec => ({
+                average: parseInt(rec.average.reduce((a,b) => a + b) / rec.average.length),
+                time: rec.time
+            }));
+        });
     },
 
     getBitcoinRatesForOneYear: function() {
-        return this.get('year');
+
     },
 
     getBitcoinRatesForOneMonth: function() {

--- a/js/apiGoranAdapter.js
+++ b/js/apiGoranAdapter.js
@@ -14,6 +14,10 @@ window.App.apiGoranAdapter = {
         }));
     },
 
+    _createDateAsUTC: function(date) {
+      return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds()));
+    },
+
     getBitcoinRatesForAll: function() {
         return this.get('all');
     },
@@ -27,17 +31,18 @@ window.App.apiGoranAdapter = {
             const nextData = {};
 
             data.forEach( rec => {
-                const date = new Date(rec.time);
-
-                const dayOfTheMonth = date.getDate();
+                const date = this._createDateAsUTC(new Date(rec.time));
                 date.setMinutes(0);
-                date.setHours(1);
+                date.setHours(0);
                 date.setSeconds(0);
 
-                if (nextData[dayOfTheMonth]) {
-                  nextData[dayOfTheMonth].average.push(rec.average);
+                const dayOfTheMonth = date.getDate();
+                const month = date.getMonth();
+                const key = `${month}-${dayOfTheMonth}`;
+                if (nextData[key]) {
+                  nextData[key].average.push(rec.average);
                 } else {
-                    nextData[dayOfTheMonth] = {
+                    nextData[key] = {
                       average: [rec.average],
                       time: date.valueOf()
                     };
@@ -52,7 +57,7 @@ window.App.apiGoranAdapter = {
             return result.map( rec => ({
                 average: parseInt(rec.average.reduce((a,b) => a + b) / rec.average.length),
                 time: rec.time
-            }));
+            })).reverse();
         });
     },
 
@@ -64,12 +69,8 @@ window.App.apiGoranAdapter = {
         return this.get('indices/global/history/BTCUSD?period=daily&?format=json').then(data => {
           const nextData = {};
 
-          function createDateAsUTC(date) {
-            return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds()));
-          }
-
           data.forEach( rec => {
-            const date = createDateAsUTC(new Date(rec.time));
+            const date = this._createDateAsUTC(new Date(rec.time));
             date.setMinutes(0);
 
             const hour = date.getHours();

--- a/js/apiGoranAdapter.js
+++ b/js/apiGoranAdapter.js
@@ -38,13 +38,14 @@ window.App.apiGoranAdapter = {
             const date = new Date(rec.time);
 
             const hour = date.getHours();
+            date.setMinutes(0);
 
             if (nextData[hour]) {
               nextData[hour].average.push(rec.average);
             } else {
                 nextData[hour] = {
                   average: [rec.average],
-                  time: rec.time
+                  time: date.valueOf()
                 };
             }
           });

--- a/js/apiGoranAdapter.js
+++ b/js/apiGoranAdapter.js
@@ -1,0 +1,67 @@
+window.App = window.App || {};
+
+window.App.apiGoranAdapter = {
+    baseURL: 'https://apiv2.bitcoinaverage.com/',
+
+    get: function(_endpoint) {
+        return App.API.get(_endpoint);
+    },
+
+    mapData: function(response, dateLabelFormat) {
+        return response.map( _rec => ({
+            value: _rec.average,
+            timestamp: moment(_rec.time).format(dateLabelFormat)
+        }));
+    },
+
+    getBitcoinRatesForAll: function() {
+        return this.get('all');
+    },
+
+    getBitcoinRatesForOneYear: function() {
+        return this.get('year');
+    },
+
+    getBitcoinRatesForOneMonth: function() {
+        return this.get('month');
+    },
+
+    getBitcoinRatesForOneWeek: function() {
+        return this.get('week');
+    },
+
+    getBitcoinRatesForOneDay: function() {
+        return this.get('indices/global/history/BTCUSD?period=daily&?format=json').then(data => {
+          const nextData = {};
+
+          data.forEach( rec => {
+            const date = new Date(rec.time);
+
+            const hour = date.getHours();
+
+            if (nextData[hour]) {
+              nextData[hour].average.push(rec.average);
+            } else {
+                nextData[hour] = {
+                  average: [rec.average],
+                  time: rec.time
+                };
+            }
+          });
+
+          const result = [];
+          for (let key of Object.keys(nextData)) {
+            result.push(nextData[key]);
+          }
+
+          return result.map( rec => ({
+            average: parseInt(rec.average.reduce((a,b) => a + b) / rec.average.length),
+            time: rec.time
+          }));
+        });
+    },
+
+    getBitcoinRatesForOneHour: function() {
+        return this.get('hour');
+    }
+};

--- a/js/apiGoranAdapter.js
+++ b/js/apiGoranAdapter.js
@@ -100,6 +100,25 @@ window.App.apiGoranAdapter = {
     },
 
     getBitcoinRatesForOneHour: function() {
-        return this.get('hour');
+      return this.get('indices/global/history/BTCUSD?period=daily&?format=json').then(data => {
+        const nextData = [];
+
+        data.forEach( rec => {
+          const date = this._createDateAsUTC(new Date(rec.time));
+          const today = new Date();
+
+          const isTheSameDay = today.getDate() === date.getDate();
+          const isTheSameHour = today.getHours() === date.getHours();
+
+          if (isTheSameDay && isTheSameHour) {
+            nextData.push({
+                average: rec.average,
+                time: date.valueOf()
+            });
+          }
+        });
+
+        return nextData.reverse();
+      });
     }
 };

--- a/js/apiGoranAdapter.js
+++ b/js/apiGoranAdapter.js
@@ -67,35 +67,35 @@ window.App.apiGoranAdapter = {
 
     getBitcoinRatesForOneDay: function() {
         return this.get('indices/global/history/BTCUSD?period=daily&?format=json').then(data => {
-          const nextData = {};
+            const nextData = {};
 
-          data.forEach( rec => {
-            const date = this._createDateAsUTC(new Date(rec.time));
-            date.setMinutes(0);
+            data.forEach( rec => {
+                const date = this._createDateAsUTC(new Date(rec.time));
+                date.setMinutes(0);
 
-            const hour = date.getHours();
-            const dayOfTheMonth = date.getDate();
-            const key = `${dayOfTheMonth}-${hour}`;
+                const hour = date.getHours();
+                const dayOfTheMonth = date.getDate();
+                const key = `${dayOfTheMonth}-${hour}`;
 
-            if (nextData[key]) {
-              nextData[key].average.push(rec.average);
-            } else {
-                nextData[key] = {
-                  average: [rec.average],
-                  time: date.valueOf()
-                };
+                if (nextData[key]) {
+                    nextData[key].average.push(rec.average);
+                } else {
+                    nextData[key] = {
+                        average: [rec.average],
+                        time: date.valueOf()
+                    };
+                }
+            });
+
+            const result = [];
+            for (let key of Object.keys(nextData)) {
+                result.push(nextData[key]);
             }
-          });
 
-          const result = [];
-          for (let key of Object.keys(nextData)) {
-            result.push(nextData[key]);
-          }
-
-          return result.map( rec => ({
-            average: parseInt(rec.average.reduce((a,b) => a + b) / rec.average.length),
-            time: rec.time
-          })).reverse();
+            return result.map( rec => ({
+                average: parseInt(rec.average.reduce((a,b) => a + b) / rec.average.length),
+                time: rec.time
+            })).reverse();
         });
     },
 
@@ -104,18 +104,18 @@ window.App.apiGoranAdapter = {
         const nextData = [];
 
         data.forEach( rec => {
-          const date = this._createDateAsUTC(new Date(rec.time));
-          const today = new Date();
+            const date = this._createDateAsUTC(new Date(rec.time));
+            const today = new Date();
 
-          const isTheSameDay = today.getDate() === date.getDate();
-          const isTheSameHour = today.getHours() === date.getHours();
+            const isTheSameDay = today.getDate() === date.getDate();
+            const isTheSameHour = today.getHours() === date.getHours();
 
-          if (isTheSameDay && isTheSameHour) {
-            nextData.push({
-                average: rec.average,
-                time: date.valueOf()
-            });
-          }
+            if (isTheSameDay && isTheSameHour) {
+                nextData.push({
+                    average: rec.average,
+                    time: date.valueOf()
+                });
+            }
         });
 
         return nextData.reverse();

--- a/js/apiGoranAdapter.js
+++ b/js/apiGoranAdapter.js
@@ -198,9 +198,9 @@ window.App.apiGoranAdapter = {
             const today = new Date();
 
             const isTheSameDay = today.getDate() === date.getDate();
-            const isTheSameHour = today.getHours() === date.getHours();
+            const isWithingAnHour = (today.valueOf() - date.valueOf()) < (60 * 60 * 1000);
 
-            if (isTheSameDay && isTheSameHour) {
+            if (isTheSameDay && isWithingAnHour) {
                 nextData.push({
                     average: rec.average,
                     time: date.valueOf()

--- a/js/apiGoranAdapter.js
+++ b/js/apiGoranAdapter.js
@@ -23,7 +23,37 @@ window.App.apiGoranAdapter = {
     },
 
     getBitcoinRatesForOneMonth: function() {
-        return this.get('month');
+        return this.get('indices/global/history/BTCUSD?period=monthly&?format=json').then(data => {
+            const nextData = {};
+
+            data.forEach( rec => {
+                const date = new Date(rec.time);
+
+                const dayOfTheMonth = date.getDate();
+                date.setMinutes(0);
+                date.setHours(1);
+                date.setSeconds(0);
+
+                if (nextData[dayOfTheMonth]) {
+                  nextData[dayOfTheMonth].average.push(rec.average);
+                } else {
+                    nextData[dayOfTheMonth] = {
+                      average: [rec.average],
+                      time: date.valueOf()
+                    };
+                }
+            });
+
+            const result = [];
+            for (let key of Object.keys(nextData)) {
+                result.push(nextData[key]);
+            }
+
+            return result.map( rec => ({
+                average: parseInt(rec.average.reduce((a,b) => a + b) / rec.average.length),
+                time: rec.time
+            }));
+        });
     },
 
     getBitcoinRatesForOneWeek: function() {

--- a/js/apiGoranAdapter.js
+++ b/js/apiGoranAdapter.js
@@ -50,7 +50,39 @@ window.App.apiGoranAdapter = {
     },
 
     getBitcoinRatesForOneYear: function() {
+        return this.get('indices/global/history/BTCUSD?period=alltime&?format=json').then(data => {
+            const nextData = {};
 
+            data.forEach( rec => {
+                const date = this._createDateAsUTC(new Date(rec.time));
+                const today = new Date();
+
+                if (today.getFullYear() !== date.getFullYear()) {
+                    return;
+                }
+
+                const month = date.getMonth();
+                const key = `${month}`;
+                if (nextData[key]) {
+                  nextData[key].average.push(rec.average);
+                } else {
+                    nextData[key] = {
+                      average: [rec.average],
+                      time: date.valueOf()
+                    };
+                }
+            });
+
+            const result = [];
+            for (let key of Object.keys(nextData)) {
+                result.push(nextData[key]);
+            }
+
+            return result.map( rec => ({
+                average: parseInt(rec.average.reduce((a,b) => a + b) / rec.average.length),
+                time: rec.time
+            }));
+        });
     },
 
     getBitcoinRatesForOneMonth: function() {

--- a/js/apiGoranAdapter.js
+++ b/js/apiGoranAdapter.js
@@ -88,7 +88,7 @@ window.App.apiGoranAdapter = {
           return result.map( rec => ({
             average: parseInt(rec.average.reduce((a,b) => a + b) / rec.average.length),
             time: rec.time
-          }));
+          })).reverse();
         });
     },
 

--- a/js/script.js
+++ b/js/script.js
@@ -43,7 +43,7 @@ $(function(){
         switch(period) {
             case 'ALL': return 'MMM YYYY';
             case 'ONE_YEAR': return 'MMM YYYY';
-            case 'ONE_MONTH': return 'do MMM';
+            case 'ONE_MONTH': return 'Do MMM';
             case 'ONE_WEEK': return 'dddd';
             case 'ONE_DAY': return 'HH:mm';
             case 'ONE_HOUR': return 'HH:mm';

--- a/js/script.js
+++ b/js/script.js
@@ -56,10 +56,7 @@ $(function(){
             storage: 'BROWSER_STORAGE',
             name: 'bitcoin-' + period,
             outOfDateAfter: 15 * 60 * 1000,
-            mapData: r => r.map( _rec => ({
-                value: _rec.average,
-                timestamp: moment(_rec.time).format(getLabelFormat(period))
-            })),
+            mapData: r => App.API.mapData(r, getLabelFormat(period)),
             request: () => getBitcoinData(period)
         })
     );

--- a/js/script.js
+++ b/js/script.js
@@ -41,7 +41,7 @@ $(function(){
 
     function getLabelFormat(period) {
         switch(period) {
-            case 'ALL': return 'MMM YYYY';
+            case 'ALL': return 'YYYY';
             case 'ONE_YEAR': return 'MMM YYYY';
             case 'ONE_MONTH': return 'Do MMM';
             case 'ONE_WEEK': return 'dddd';

--- a/js/script.js
+++ b/js/script.js
@@ -51,9 +51,9 @@ $(function(){
             storage: 'BROWSER_STORAGE',
             name: 'bitcoin',
             outOfDateAfter: 15 * 1000,
-            mapData: r => r.data.map( _rec => ({
-                value: _rec.value,
-                timestamp: moment(_rec.timestamp).format(dateFormat)
+            mapData: r => r.map( _rec => ({
+                value: _rec.average,
+                timestamp: moment(_rec.time).format(dateFormat)
             })),
             request: () => getBitcoinData(period)
         });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "homepage": "https://github.com/superKalo/crypto-chart-new-tab-extension#readme",
   "dependencies": {
+    "axios": "0.16.2",
     "chart.js": "2.6.0",
     "jquery": "3.2.1",
     "moment": "2.18.1",


### PR DESCRIPTION
Use Axios for doing the AJAX requests, instead of jQuery's `$.ajax()`.

Refactor the API architecture to use adapters. Excellent for scalability. Then, move the fake API into it's own adapter.

Integrate a random Bitcoin API adapter, which my friend Goran found, just for the test. I hope Ceco manages to deploy the real API VERY SOON. HE PROMISED ME.